### PR TITLE
contextLoads() 테스트 관련 에러

### DIFF
--- a/src/test/java/com/springboard/projectboard/SpringBoardApplicationTests.java
+++ b/src/test/java/com/springboard/projectboard/SpringBoardApplicationTests.java
@@ -2,9 +2,15 @@ package com.springboard.projectboard;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
-@SpringBootTest(properties = "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration")
+import javax.sql.DataSource;
+
+@SpringBootTest
 class SpringBoardApplicationTests {
+
+	@MockBean
+	private DataSource dataSource;
 
 	@Test
 	void contextLoads() {

--- a/src/test/java/com/springboard/projectboard/SpringBoardApplicationTests.java
+++ b/src/test/java/com/springboard/projectboard/SpringBoardApplicationTests.java
@@ -3,7 +3,7 @@ package com.springboard.projectboard;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+@SpringBootTest(properties = "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration")
 class SpringBoardApplicationTests {
 
 	@Test


### PR DESCRIPTION
- contextLoads()의 DB 의존 제거
--현재 계속 이 테스트를 통과하지 못하는 중.
--테스트 겸 수정 적용 해보았다.